### PR TITLE
Attendant dev

### DIFF
--- a/com.thelocalmarketplace.software.test/src/com/thelocalmarketplace/software/test/attendant/IssuesPredictorTest.java
+++ b/com.thelocalmarketplace.software.test/src/com/thelocalmarketplace/software/test/attendant/IssuesPredictorTest.java
@@ -81,8 +81,9 @@ public class IssuesPredictorTest extends AbstractSessionTest{
 		
 		as = new Attendant(new AttendantStation());
 		// create issuePredictor instance
-        issuePredictor = new IssuePredictor(session, scs);
-        as.addIssuePrediction(issuePredictor);
+		as.registerOn(session, scs);
+        as.addIssuePrediction(session);
+        issuePredictor = as.getIssuePredictor(session);
         
 		// Create power source
 		PowerGrid.engageUninterruptiblePowerSource();

--- a/com.thelocalmarketplace.software.test/src/com/thelocalmarketplace/software/test/attendant/MaintenanceManagerTest.java
+++ b/com.thelocalmarketplace.software.test/src/com/thelocalmarketplace/software/test/attendant/MaintenanceManagerTest.java
@@ -89,11 +89,11 @@ public class MaintenanceManagerTest extends AbstractSessionTest {
         station.plugIn(powerGrid);
         station.turnOn();
         attendant = new Attendant(station);
-        attendant.registerOn(session);
+        attendant.registerOn(session,scs);
 
         maintenanceManager = new MaintenanceManager();
-        predictor = new IssuePredictor(session, scs);
-        attendant.addIssuePrediction(predictor);
+        attendant.addIssuePrediction(session);
+        predictor = attendant.getIssuePredictor(session);
 
         Coin.DEFAULT_CURRENCY = Currency.getInstance(Locale.CANADA);
         nickel = new Coin(new BigDecimal(0.05));

--- a/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/InvalidActionException.java
+++ b/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/InvalidActionException.java
@@ -5,17 +5,29 @@ package com.thelocalmarketplace.software.exceptions;
  * not able to be used. For example, this can occur when an item is attempted to be
  * added when the session is frozen. Thus, this is an invalidAction to occur.
  * 
- * Project iteration 2 group members:
- * 		Aj Sallh 				: 30023811
- *		Anthony Kostal-Vazquez 	: 30048301
- *		Chloe Robitaille 		: 30022887
- *		Dvij Raval				: 30024340
- *		Emily Kiddle 			: 30122331
- *		Katelan NG 				: 30144672
- *		Kingsley Zhong 			: 30197260
- *		Nick McCamis 			: 30192610
- *		Sua Lim 				: 30177039
- *		Subeg CHAHAL 			: 30196531
+ * Project Iteration 3 Group 1
+ *
+ * Derek Atabayev : 30177060
+ * Enioluwafe Balogun : 30174298
+ * Subeg Chahal : 30196531
+ * Jun Heo : 30173430
+ * Emily Kiddle : 30122331
+ * Anthony Kostal-Vazquez : 30048301
+ * Jessica Li : 30180801
+ * Sua Lim : 30177039
+ * Savitur Maharaj : 30152888
+ * Nick McCamis : 30192610
+ * Ethan McCorquodale : 30125353
+ * Katelan Ng : 30144672
+ * Arcleah Pascual : 30056034
+ * Dvij Raval : 30024340
+ * Chloe Robitaille : 30022887
+ * Danissa Sandykbayeva : 30200531
+ * Emily Stein : 30149842
+ * Thi My Tuyen Tran : 30193980
+ * Aoi Ueki : 30179305
+ * Ethan Woo : 30172855
+ * Kingsley Zhong : 30197260
  */
 @SuppressWarnings("serial")
 public class InvalidActionException extends RuntimeException{

--- a/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/NotEnoughChangeException.java
+++ b/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/NotEnoughChangeException.java
@@ -2,17 +2,29 @@ package com.thelocalmarketplace.software.exceptions;
 /**
  * Exception that occurs when there is not enough change in the machine to dispense to the customer
  * 
- * Project iteration 2 group members:
- * 		Aj Sallh 				: 30023811
- *		Anthony Kostal-Vazquez 	: 30048301
- *		Chloe Robitaille 		: 30022887
- *		Dvij Raval				: 30024340
- *		Emily Kiddle 			: 30122331
- *		Katelan NG 				: 30144672
- *		Kingsley Zhong 			: 30197260
- *		Nick McCamis 			: 30192610
- *		Sua Lim 				: 30177039
- *		Subeg CHAHAL 			: 30196531
+ * Project Iteration 3 Group 1
+ *
+ * Derek Atabayev : 30177060
+ * Enioluwafe Balogun : 30174298
+ * Subeg Chahal : 30196531
+ * Jun Heo : 30173430
+ * Emily Kiddle : 30122331
+ * Anthony Kostal-Vazquez : 30048301
+ * Jessica Li : 30180801
+ * Sua Lim : 30177039
+ * Savitur Maharaj : 30152888
+ * Nick McCamis : 30192610
+ * Ethan McCorquodale : 30125353
+ * Katelan Ng : 30144672
+ * Arcleah Pascual : 30056034
+ * Dvij Raval : 30024340
+ * Chloe Robitaille : 30022887
+ * Danissa Sandykbayeva : 30200531
+ * Emily Stein : 30149842
+ * Thi My Tuyen Tran : 30193980
+ * Aoi Ueki : 30179305
+ * Ethan Woo : 30172855
+ * Kingsley Zhong : 30197260
  */
 @SuppressWarnings("serial")
 public class NotEnoughChangeException extends RuntimeException{

--- a/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/ProductNotFoundException.java
+++ b/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/ProductNotFoundException.java
@@ -4,17 +4,29 @@ package com.thelocalmarketplace.software.exceptions;
  * Exception that occurs when an action in unable to occur due to 
  * the product no being found in the list.
  * 
- * Project iteration 2 group members:
- * 		Aj Sallh 				: 30023811
- *		Anthony Kostal-Vazquez 	: 30048301
- *		Chloe Robitaille 		: 30022887
- *		Dvij Raval				: 30024340
- *		Emily Kiddle 			: 30122331
- *		Katelan NG 				: 30144672
- *		Kingsley Zhong 			: 30197260
- *		Nick McCamis 			: 30192610
- *		Sua Lim 				: 30177039
- *		Subeg CHAHAL 			: 30196531
+ * Project Iteration 3 Group 1
+ *
+ * Derek Atabayev : 30177060
+ * Enioluwafe Balogun : 30174298
+ * Subeg Chahal : 30196531
+ * Jun Heo : 30173430
+ * Emily Kiddle : 30122331
+ * Anthony Kostal-Vazquez : 30048301
+ * Jessica Li : 30180801
+ * Sua Lim : 30177039
+ * Savitur Maharaj : 30152888
+ * Nick McCamis : 30192610
+ * Ethan McCorquodale : 30125353
+ * Katelan Ng : 30144672
+ * Arcleah Pascual : 30056034
+ * Dvij Raval : 30024340
+ * Chloe Robitaille : 30022887
+ * Danissa Sandykbayeva : 30200531
+ * Emily Stein : 30149842
+ * Thi My Tuyen Tran : 30193980
+ * Aoi Ueki : 30179305
+ * Ethan Woo : 30172855
+ * Kingsley Zhong : 30197260
  */
 @SuppressWarnings("serial")
 public class ProductNotFoundException extends InvalidActionException {

--- a/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/SessionNotRegisteredException.java
+++ b/com.thelocalmarketplace.software/Exceptions/com/thelocalmarketplace/software/exceptions/SessionNotRegisteredException.java
@@ -1,8 +1,8 @@
 package com.thelocalmarketplace.software.exceptions;
-
-/**
- * Exception that occurs when an action in unable to occur due to 
- * the shopping cart being empty.
+/*
+ * Exception to be thrown when an Attendant is asked for information about an instance of Session it is
+ * not tracking (eg. associated hardware, current request, associated prediction software).
+ * 
  * 
  * Project Iteration 3 Group 1
  *
@@ -27,16 +27,11 @@ package com.thelocalmarketplace.software.exceptions;
  * Aoi Ueki : 30179305
  * Ethan Woo : 30172855
  * Kingsley Zhong : 30197260
- */
+*/
 @SuppressWarnings("serial")
-public class CartEmptyException extends InvalidActionException{
-	/**
-	 * Basic constructor
-	 * 
-	 * @param message
-	 * 			An explanatory message of the problem
-	 */
-	public CartEmptyException(String message) {
-		super(message);
+public class SessionNotRegisteredException extends RuntimeException{
+
+	public SessionNotRegisteredException() {
+		super("This isntance of Session is not registered with this Attendant.");
 	}
 }

--- a/com.thelocalmarketplace.software/GUI/com/thelocalmarketplace/GUI/Simulation.java
+++ b/com.thelocalmarketplace.software/GUI/com/thelocalmarketplace/GUI/Simulation.java
@@ -78,7 +78,7 @@ public class Simulation {
 		manager = new MaintenanceManager();
 		manager.openHardware(session);
 		
-		predictor = new IssuePredictor(session, scs);
+		predictor = attendant.getIssuePredictor(session);
 		
 		hardwareGUI = new HardwareGUI(scs, as);
 		attendantGUI = new AttendantGUI(attendant, manager, predictor);

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/SelfCheckoutStationLogic.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/SelfCheckoutStationLogic.java
@@ -27,7 +27,7 @@ import com.thelocalmarketplace.software.weight.Weight;
  * station.
  * Creates and associates Attendants and Sessions.
  *
- * Allows for a database to be constructed
+ * Allows for a product database to be constructed
  *
  * Project Iteration 3 Group 1
  *
@@ -60,18 +60,20 @@ public class SelfCheckoutStationLogic {
 	private Session session;
 	private IssuePredictor predictor;
 
+	/**
+	 * Installs an instance of Attendant onto an AttendantStation
+	 * @param as
+	 * 				an instance of AttendantStation hardware
+	 */
 	public static void installAttendantStation(AttendantStation as) {
 		attendant = new Attendant(as);
 	}
 
 	/**
-	 * Installs an instance of the logic on the selfCheckoutStation and the session
-	 * run on the station
+	 * Installs an instance of the Session logic on the selfCheckoutStation. 
 	 *
 	 * @param scs
 	 *                The self-checkout station that the logic shall be installed
-	 * @param session
-	 *                The session that the logic shall be installed on
 	 * @return
 	 *         returns an instance of the SelfCheckoutStationLogic on a
 	 *         SelfChekoutStation and Session
@@ -85,8 +87,6 @@ public class SelfCheckoutStationLogic {
 	 *
 	 * @param scs
 	 *                The self-checkout station that the logic is installed on
-	 * @param session
-	 *                The session that the logic shall be installed on
 	 */
 	private SelfCheckoutStationLogic(AbstractSelfCheckoutStation scs) {
 		// creates a new Session
@@ -94,29 +94,27 @@ public class SelfCheckoutStationLogic {
 
 		// Registers the attendant with the session
 		// issue predictor??
-		attendant.registerOn(session);
-		//System.out.println("SESSIONS: "+attendant.getSessions().size());
+		attendant.registerOn(session, scs);
 
-		// create Funds, Weight, Receipt, and ItemManger classes to associate w/ Session
+		// create Funds, Weight, Receipt, Membership, and ItemManger classes to associate w/ Session
 		Funds funds = new Funds(scs);
 		new PayByCash(scs.getCoinValidator(), scs.getBanknoteValidator(), funds);
 		new PayByCard(scs.getCardReader(), funds);
 		Weight weight = new Weight(scs.getBaggingArea());
-		Receipt receiptPrinter = new Receipt(scs.getPrinter());
+		Receipt receipt = new Receipt(scs.getPrinter());
 		ItemManager itemManager = new ItemManager();
 		Membership membership = new Membership(scs.getCardReader());
-		// Will also need the touch screen/ keyboard for GUI interaction
-		session.setup(itemManager, funds, weight, receiptPrinter, membership, scs);
 
+		session.setup(itemManager, funds, weight, receipt, membership, scs);
+
+		// register scanner and handheld scanner with the item manager
 		new ItemAddedRule(scs.getMainScanner(), scs.getHandheldScanner(), itemManager);
-
-		// Register IssuePredictor with Session
-		this.predictor  = new IssuePredictor(session, scs);
-		// tell the Attendant about the Predictor
-		attendant.addIssuePrediction(predictor);
-
 		// register scanning area scale with the PLU Item manager
 		new PLUItemAddedRule(scs.getScanningArea(), itemManager);
+		
+		// Attendant will create an IssuePredictor to go with the provided session
+		attendant.addIssuePrediction(session);
+
 	}
 
 	public static Attendant getAttendant() {

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/SelfCheckoutStationLogic.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/SelfCheckoutStationLogic.java
@@ -58,7 +58,6 @@ public class SelfCheckoutStationLogic {
 
 	private static Attendant attendant;
 	private Session session;
-	private IssuePredictor predictor;
 
 	/**
 	 * Installs an instance of Attendant onto an AttendantStation
@@ -123,10 +122,6 @@ public class SelfCheckoutStationLogic {
 
 	public Session getSession() {
 		return session;
-	}
-	
-	public IssuePredictor getPredictor() {
-		return predictor;
 	}
 
 	/**

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/Session.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/Session.java
@@ -64,7 +64,7 @@ import ca.ucalgary.seng300.simulation.NullPointerSimulationException;
  *
  */
 public class Session {
-	public ArrayList<SessionListener> listeners = new ArrayList<>();
+	private ArrayList<SessionListener> listeners = new ArrayList<>();
 	private ArrayList<HardwareListener> hardwareListeners = new ArrayList<>();
 	private AbstractSelfCheckoutStation scs;
 	protected SessionState sessionState;
@@ -228,43 +228,6 @@ public class Session {
 	}
 	
 	/**
-	 * Handles receiving notifications from the Attendant when a request has been made
-	 * 
-	 */
-	private class InnerAttendantListener implements AttendantListener{
-
-		@Override
-		public void notifyOverrideWeightDiscrepancy() {
-			
-		}
-
-		@Override
-		public void notifyOkayBulkyItem() {
-			// TODO Auto-generated method stub
-			
-		}
-
-		@Override
-		public void notifyOkayHeavyBags() {
-			// TODO Auto-generated method stub
-			
-		}
-
-		@Override
-		public void notifyForceEndSession() {
-			// TODO Auto-generated method stub
-			
-		}
-
-		@Override
-		public void notifyRequestResolved() {
-			// TODO Auto-generated method stub
-			
-		}
-		
-	}
-	
-	/**
 	 * Constructor for the session method. Requires to be installed on self-checkout
 	 * system
 	 * with logic to function
@@ -349,7 +312,11 @@ public class Session {
 		sessionState = SessionState.BLOCKED;
 		manager.setAddItems(false);
 	}
-
+	
+	/**
+	 * Ends the current session, returning state to PRE_SESSION.
+	 * 
+	 */
 	private void end() {
 		prevState = sessionState;
 		sessionState = SessionState.PRE_SESSION;
@@ -381,7 +348,7 @@ public class Session {
 	 *
 	 * @throws InvalidActionException
 	 */
-	public void enteringMembership() {
+	public void enterMembership() {
 		if (sessionState == SessionState.IN_SESSION) {
 			membership.setAddingItems(true);
 		} else {
@@ -493,7 +460,7 @@ public class Session {
 		}	
 	}
 	
-	// Move to receiptPrinter class (possible rename of receiptPrinter to just reciept
+	// Move to receiptPrinter class 
 	public void printReceipt() {
 		receipt.printReceipt(manager.getItems());
 	}
@@ -530,8 +497,27 @@ public class Session {
 	 */
 	public void attendantApprove(Requests request) {
 		requestApproved = true;
-		if (request == Requests.BULKY_ITEM) {
+		switch(request) {
+		case ADD_ITEM_SEARCH:
+			break;
+		case BAGS_TOO_HEAVY:
+			break;
+		case BULKY_ITEM:
 			addBulkyItem();
+			break;
+		case CANT_MAKE_CHANGE:
+			break;
+		case CANT_PRINT_RECEIPT:
+			break;
+		case HELP_REQUESTED:
+			break;
+		case NO_REQUEST:
+			break;
+		case WEIGHT_DISCREPANCY:
+			break;
+		default:
+			break;
+		
 		}
 	}
 
@@ -559,7 +545,7 @@ public class Session {
 	/**
 	 * Called when hardware for the session is opened
 	 */
-	public void openHardware() {
+	public void notifyOpenHardware() {
 		for (HardwareListener l: hardwareListeners) {
 			l.aStationHasBeenOpened();
 		}
@@ -568,7 +554,7 @@ public class Session {
 	/**
 	 * Called when hardware for the session is closed
 	 */
-	public void closeHardware() {
+	public void notifyCloseHardware() {
 		for (HardwareListener l : hardwareListeners) {
 			l.aStationHasBeenClosed();
 		}

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/Session.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/Session.java
@@ -8,10 +8,9 @@ import com.jjjwelectronics.Mass;
 import com.thelocalmarketplace.hardware.AbstractSelfCheckoutStation;
 import com.thelocalmarketplace.hardware.BarcodedProduct;
 import com.thelocalmarketplace.hardware.PLUCodedProduct;
-import com.thelocalmarketplace.hardware.PriceLookUpCode;
 import com.thelocalmarketplace.hardware.Product;
+import com.thelocalmarketplace.software.attendant.AttendantListener;
 import com.thelocalmarketplace.software.attendant.HardwareListener;
-import com.thelocalmarketplace.software.attendant.IssuePredictor;
 import com.thelocalmarketplace.software.attendant.Requests;
 import com.thelocalmarketplace.software.exceptions.CartEmptyException;
 import com.thelocalmarketplace.software.exceptions.InvalidActionException;
@@ -20,7 +19,6 @@ import com.thelocalmarketplace.software.funds.FundsListener;
 import com.thelocalmarketplace.software.items.ItemListener;
 import com.thelocalmarketplace.software.items.ItemManager;
 import com.thelocalmarketplace.software.membership.Membership;
-import com.thelocalmarketplace.software.membership.MembershipListener;
 import com.thelocalmarketplace.software.receipt.Receipt;
 import com.thelocalmarketplace.software.receipt.ReceiptListener;
 import com.thelocalmarketplace.software.weight.Weight;
@@ -228,7 +226,44 @@ public class Session {
 		}
 
 	}
+	
+	/**
+	 * Handles receiving notifications from the Attendant when a request has been made
+	 * 
+	 */
+	private class InnerAttendantListener implements AttendantListener{
 
+		@Override
+		public void notifyOverrideWeightDiscrepancy() {
+			
+		}
+
+		@Override
+		public void notifyOkayBulkyItem() {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public void notifyOkayHeavyBags() {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public void notifyForceEndSession() {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public void notifyRequestResolved() {
+			// TODO Auto-generated method stub
+			
+		}
+		
+	}
+	
 	/**
 	 * Constructor for the session method. Requires to be installed on self-checkout
 	 * system
@@ -511,7 +546,7 @@ public class Session {
 	 */
 	public void notifyAttendant(Requests request) {
 		for (SessionListener l : listeners) {
-			//l.getRequest(this, request);
+			l.getRequest(this, request);
 		}
 	}
 	
@@ -548,9 +583,7 @@ public class Session {
 	/**
 	 * getter methods
 	 */
-	public boolean getRequestApproved() {
-		return this.requestApproved;
-	}
+
 
 	public HashMap<Product, BigInteger> getItems() {
 		return manager.getItems();

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/SessionListener.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/SessionListener.java
@@ -40,8 +40,7 @@ public interface SessionListener {
 	 * @param request
 	 */
 	void getRequest(Session session, Requests request);
-	
-	
+
 	void itemAdded(Session session, Product product, Mass ofProduct, Mass currentExpectedWeight, BigDecimal currentExpectedPrice);
 	
 	void itemRemoved(Session session, Product product, Mass ofProduct, Mass currentExpectedMass, BigDecimal currentExpectedPrice);

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Attendant.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Attendant.java
@@ -230,6 +230,8 @@ public class Attendant {
 	}
 
 
+	
+	
 	/**
 	 * Method for enabling a Customer SelfCheckoutStation associated with a given session, unlocking the 
 	 * Session and putting it into the PRE_SESSION state
@@ -408,10 +410,21 @@ public class Attendant {
 			throw new SessionNotRegisteredException();
 		}
 	}
+	
+	/**
+	 * Returns the set of all sessions being tracked by this Attendant
+	 * @return
+	 * 			HashMap<Session, Requests>
+	 */
 	public HashMap<Session, Requests> getSessions(){
 		return sessions;
 	}
 
+	/**
+	 * Returns the instance of TextSearchController associated with this Attendant
+	 * @return
+	 * 			TextSearchController
+	 */
 	public TextSearchController getTextSearchController() {
 		return ts;
 	}

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Attendant.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Attendant.java
@@ -231,6 +231,22 @@ public class Attendant {
 
 
 	
+	/**
+	 * Handles all possible ways an attendant could "approve" a customer's request
+	 * @param session
+	 * 					an instance of Session
+	 */
+	public void approveRequest(Session session) {
+		if(sessions.containsKey(session)) {
+			Requests request = sessions.get(session);
+			session.attendantApprove(request);// session will have to handle the rest
+		}
+		else {
+			throw new SessionNotRegisteredException();
+		}
+		
+	}
+	
 	
 	/**
 	 * Method for enabling a Customer SelfCheckoutStation associated with a given session, unlocking the 

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Attendant.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Attendant.java
@@ -8,6 +8,7 @@ import ca.ucalgary.seng300.simulation.NullPointerSimulationException;
 import com.jjjwelectronics.DisabledDevice;
 import com.jjjwelectronics.Mass;
 import com.jjjwelectronics.keyboard.USKeyboardQWERTY;
+import com.thelocalmarketplace.hardware.AbstractSelfCheckoutStation;
 import com.thelocalmarketplace.hardware.AttendantStation;
 import com.thelocalmarketplace.hardware.BarcodedProduct;
 import com.thelocalmarketplace.hardware.PLUCodedProduct;
@@ -15,6 +16,7 @@ import com.thelocalmarketplace.hardware.Product;
 import com.thelocalmarketplace.software.Session;
 import com.thelocalmarketplace.software.SessionListener;
 import com.thelocalmarketplace.software.exceptions.ProductNotFoundException;
+import com.thelocalmarketplace.software.exceptions.SessionNotRegisteredException;
 
 /**
  * Simulation of attendant station, its functions, and its interactions with customer stations/session
@@ -48,16 +50,65 @@ public class Attendant {
 	private AttendantStation as;
 	private TextSearchController ts;
 	private HashMap<Session, Requests> sessions = new HashMap<>();
+	private HashMap<Session, IssuePredictor> predictors = new HashMap<>();
+	private HashMap<Session, AbstractSelfCheckoutStation> stations = new HashMap<>();
 	public ArrayList<AttendantListener> listeners = new ArrayList<>();
 	
 	/**
-	 * default constructor
+	 * Creates an instance of class Attendant given an instance of hardware AttendantStation.
+	 * Associates the Attendant with the keyboard.
+	 * 
+	 * @param as
+	 * 				an instance of type AttendantStation
 	 */
 	public Attendant(AttendantStation as) {
 		this.as = as;
 		ts = new TextSearchController(as.keyboard);
 	}
 
+	/**
+	 * Registers an instance of Session with this instance of Attendant.
+	 * Attendant will be added as a listener to the given instance of Session.
+	 * 
+	 * @param session
+	 * 					an instance of Session
+	 */
+	public void registerOn(Session session, AbstractSelfCheckoutStation scs) {
+		// register the Attendant as a listener
+		session.register(new InnerSessionListener());
+		
+		//add the customer station hardware to the hardware tracker
+		as.add(scs);
+		// associate the hardware with the Session
+		stations.put(session, scs);
+		
+		// start tracking the session and its requests
+		sessions.put(session,Requests.NO_REQUEST);// by default a Session has no request
+	}
+	
+	/**
+	 * Method for associating the Attendant with an instance of IssuePredictor.
+	 * @param session
+	 * 						an instance of Session
+	 */
+	public void addIssuePrediction(Session session) {
+		// checks if this Attendant is tracking this Session
+		if(sessions.containsKey(session)) {
+			//// creates an instance of IssuePredictor, associates it with session
+			// get the hardware associated with this Session
+			IssuePredictor predictor = new IssuePredictor(session, stations.get(session));
+
+			// associates the inner issue predictor listener with the predictor
+			predictor.register(new InnerPredictionListener());
+			
+			// adds the issuer predictor to the HashMap
+			predictors.put(session, predictor);			
+		}
+		else {
+			throw new SessionNotRegisteredException();
+		}
+	}
+	
 	/**
 	 * Receives updates about changes in instances of Session
 	 * Used to get messages from Customers (eg. weight discrepancy, help request)
@@ -108,30 +159,27 @@ public class Attendant {
 		 */
 		@Override
 		public void getRequest(Session session, Requests request) {
-			sessions.put(session, request);
+			sessions.put(session, request);// update the request for this Session
 		}
 
 		@Override
 		public void sessionAboutToStart(Session session) {
-			// TODO Auto-generated method stub
 			
 		}
 
 		@Override
 		public void sessionEnded(Session session) {
-			// TODO Auto-generated method stub
+			sessions.put(session,  Requests.NO_REQUEST); // resets the current Request to be NO_REQUEST
 			
 		}
 
 		@Override
 		public void pluCodeEntered(PLUCodedProduct product) {
-			// TODO Auto-generated method stub
 			
 		}
 
 		@Override
 		public void sessionStateChanged() {
-			// TODO Auto-generated method stub
 			
 		}
 	}
@@ -140,11 +188,6 @@ public class Attendant {
 	/**
 	 * Receives notifications when an issue (eg. low ink, paper, low coins) is likely to occur for a given Session
 	 * Used to let Attendant know when a customer station might have issues before they happen.
-	 * 
-	 * @param session
-	 * 					an instance of Session tha the Attendant is responsible for acting on
-	 * 
-	 * 
 	 * 
 	 */
 	private class InnerPredictionListener implements IssuePredictorListener{
@@ -185,12 +228,7 @@ public class Attendant {
 		}
 
 	}
-	public void registerOn(Session session) {
-		// register the Attendant as a listener
-		session.register(new InnerSessionListener());
-		// start tracking the session and its requests
-		sessions.put(session,Requests.NO_REQUEST);
-	}
+
 
 	/**
 	 * Method for enabling a Customer SelfCheckoutStation associated with a given session, unlocking the 
@@ -310,17 +348,65 @@ public class Attendant {
 		}
 	}
 
-	/**
-	 * Method for associating the Attendant with an instance of IssuePredictor.
-	 * @param predictor
-	 * 						an instance of IssuePredictor
-	 */
-	public void addIssuePrediction(IssuePredictor predictor) {
-		// associates the inner issue predictor class with the predictor
-		predictor.register(new InnerPredictionListener());
-	}
+
 	public AttendantStation getStation() {
 		return as;
+	}
+	/**
+	 * Returns the customer station hardware associated with a given instance of Session,
+	 * if the Session is registered  with this Attendant.
+	 * 
+	 * @param session
+	 * 					an instance of Session
+	 * @return
+	 * 					AbstractSelfCheckoutStation
+	 */
+	public AbstractSelfCheckoutStation getCustomerStation(Session session) {
+		// check if this Attendant is tracking this session
+		if(sessions.containsKey(session)) {
+			return stations.get(session);
+		}
+		else {
+			throw new SessionNotRegisteredException();
+		}
+	}
+	
+	/**
+	 * Returns the prediction software (IssuePredictor) associated with a given instance of Session,
+	 * if the Session is registered with this Attendant. 
+	 * 
+	 * @param session
+	 * 					an instance of Session
+	 * @return
+	 * 					IssuePredictor
+	 */
+	public IssuePredictor getIssuePredictor(Session session) {
+		// check if this Attendant is tracking this session
+		if(sessions.containsKey(session)) {
+			return predictors.get(session);
+		}
+		else {
+			throw new SessionNotRegisteredException();
+		}
+	}
+	
+	/**
+	 * Returns the current Request of a given instance of Session, if this Attendant is tracking
+	 * the given Session.
+	 * 
+	 * @param session
+	 * 					an instance of Session
+	 * @return
+	 * 					Requests
+	 */
+	public Requests getCurrentRequest(Session session) {
+		// check if this Attendant is tracking this session
+		if(sessions.containsKey(session)) {
+			return sessions.get(session);
+		}
+		else {
+			throw new SessionNotRegisteredException();
+		}
 	}
 	public HashMap<Session, Requests> getSessions(){
 		return sessions;

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/AttendantListener.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/AttendantListener.java
@@ -1,6 +1,41 @@
 package com.thelocalmarketplace.software.attendant;
-
+/**
+ * Interface for an attendant listener class
+ * 
+ * Project Iteration 3 Group 1
+ *
+ * Derek Atabayev 			: 30177060 
+ * Enioluwafe Balogun 		: 30174298 
+ * Subeg Chahal 			: 30196531 
+ * Jun Heo 					: 30173430 
+ * Emily Kiddle 			: 30122331 
+ * Anthony Kostal-Vazquez 	: 30048301 
+ * Jessica Li 				: 30180801 
+ * Sua Lim 					: 30177039 
+ * Savitur Maharaj 			: 30152888 
+ * Nick McCamis 			: 30192610 
+ * Ethan McCorquodale 		: 30125353 
+ * Katelan Ng 				: 30144672 
+ * Arcleah Pascual 			: 30056034 
+ * Dvij Raval 				: 30024340 
+ * Chloe Robitaille 		: 30022887 
+ * Danissa Sandykbayeva 	: 30200531 
+ * Emily Stein 				: 30149842 
+ * Thi My Tuyen Tran 		: 30193980 
+ * Aoi Ueki 				: 30179305 
+ * Ethan Woo 				: 30172855 
+ * Kingsley Zhong 			: 30197260
+ */
 public interface AttendantListener {
 	
+	public void notifyOverrideWeightDiscrepancy();
+	
+	public void notifyOkayBulkyItem();
+	
+	public void notifyOkayHeavyBags();
+	
+	public void notifyForceEndSession();
+	
+	public void notifyRequestResolved();
 	
 }

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/HardwareListener.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/HardwareListener.java
@@ -1,5 +1,29 @@
 package com.thelocalmarketplace.software.attendant;
-
+/**
+ * Project Iteration 3 Group 1
+ *
+ * Derek Atabayev 			: 30177060 
+ * Enioluwafe Balogun 		: 30174298 
+ * Subeg Chahal 			: 30196531 
+ * Jun Heo 					: 30173430 
+ * Emily Kiddle 			: 30122331 
+ * Anthony Kostal-Vazquez 	: 30048301 
+ * Jessica Li 				: 30180801 
+ * Sua Lim 					: 30177039 
+ * Savitur Maharaj 			: 30152888 
+ * Nick McCamis 			: 30192610 
+ * Ethan McCorquodale 		: 30125353 
+ * Katelan Ng 				: 30144672 
+ * Arcleah Pascual 			: 30056034 
+ * Dvij Raval 				: 30024340 
+ * Chloe Robitaille 		: 30022887 
+ * Danissa Sandykbayeva 	: 30200531 
+ * Emily Stein 				: 30149842 
+ * Thi My Tuyen Tran 		: 30193980 
+ * Aoi Ueki 				: 30179305 
+ * Ethan Woo 				: 30172855 
+ * Kingsley Zhong 		   	: 30197260 
+ */
 public interface HardwareListener {
     void aStationHasBeenOpened();
     void aStationHasBeenClosed();

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/MaintenanceManager.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/MaintenanceManager.java
@@ -1,9 +1,7 @@
 package com.thelocalmarketplace.software.attendant;
 
 import ca.ucalgary.seng300.simulation.NullPointerSimulationException;
-import ca.ucalgary.seng300.simulation.SimulationException;
 import com.jjjwelectronics.OverloadedDevice;
-import com.jjjwelectronics.bag.ReusableBagDispenserListener;
 import com.jjjwelectronics.printer.IReceiptPrinter;
 import com.tdc.CashOverloadException;
 import com.tdc.banknote.Banknote;
@@ -14,7 +12,6 @@ import com.tdc.coin.CoinStorageUnit;
 import com.tdc.coin.ICoinDispenser;
 import com.thelocalmarketplace.hardware.AbstractSelfCheckoutStation;
 import com.thelocalmarketplace.software.Session;
-import com.thelocalmarketplace.software.SessionListener;
 import com.thelocalmarketplace.software.SessionState;
 import com.thelocalmarketplace.software.exceptions.ClosedHardwareException;
 import com.thelocalmarketplace.software.exceptions.IncorrectDenominationException;
@@ -84,7 +81,7 @@ public class MaintenanceManager {
         state = session.getState();
         if (state == SessionState.DISABLED) {
             scs = session.getStation();
-            session.openHardware();
+            session.notifyOpenHardware();
             banknoteDenominations = scs.getBanknoteDenominations();
             coinDenominations = scs.getCoinDenominations();
             receiptPrinter = scs.getPrinter();
@@ -200,7 +197,7 @@ public class MaintenanceManager {
      * Simulates closing the hardware
      */
     public void closeHardware() {
-        session.closeHardware();
+        session.notifyCloseHardware();
         session = null;
         state = null;
         scs = null;

--- a/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Requests.java
+++ b/com.thelocalmarketplace.software/src/com/thelocalmarketplace/software/attendant/Requests.java
@@ -5,37 +5,37 @@ package com.thelocalmarketplace.software.attendant;
  * 
  * Project Iteration 3 Group 1
  *
- * Derek Atabayev : 30177060
- * Enioluwafe Balogun : 30174298
- * Subeg Chahal : 30196531
- * Jun Heo : 30173430
- * Emily Kiddle : 30122331
+ * Derek Atabayev : 		30177060
+ * Enioluwafe Balogun :	 	30174298
+ * Subeg Chahal : 			30196531
+ * Jun Heo : 				30173430
+ * Emily Kiddle : 			30122331
  * Anthony Kostal-Vazquez : 30048301
- * Jessica Li : 30180801
- * Sua Lim : 30177039
- * Savitur Maharaj : 30152888
- * Nick McCamis : 30192610
- * Ethan McCorquodale : 30125353
- * Katelan Ng : 30144672
- * Arcleah Pascual : 30056034
- * Dvij Raval : 30024340
- * Chloe Robitaille : 30022887
- * Danissa Sandykbayeva : 30200531
- * Emily Stein : 30149842
- * Thi My Tuyen Tran : 30193980
- * Aoi Ueki : 30179305
- * Ethan Woo : 30172855
- * Kingsley Zhong : 30197260
+ * Jessica Li : 			30180801
+ * Sua Lim : 				30177039
+ * Savitur Maharaj :		30152888
+ * Nick McCamis : 			30192610
+ * Ethan McCorquodale : 	30125353
+ * Katelan Ng : 			30144672
+ * Arcleah Pascual : 		30056034
+ * Dvij Raval : 			30024340
+ * Chloe Robitaille : 		30022887
+ * Danissa Sandykbayeva : 	30200531
+ * Emily Stein : 			30149842
+ * Thi My Tuyen Tran :		30193980
+ * Aoi Ueki : 				30179305
+ * Ethan Woo : 				30172855
+ * Kingsley Zhong :			 30197260
  */
 public enum Requests {
 	// core requests based on Use case version 3
-	NO_REQUEST,
-	WEIGHT_DISCREPANCY,
-	BAGS_TOO_HEAVY,
-	BULKY_ITEM,
-	CANT_MAKE_CHANGE,
-	CANT_PRINT_RECEIPT,
-	ADD_ITEM_SEARCH,
-	HELP_REQUESTED;
+	NO_REQUEST,// session has no request of the attendant
+	WEIGHT_DISCREPANCY,// weight discrepancy is occurring
+	BAGS_TOO_HEAVY,// bags added to the bagging area are over the maximum allowed bag weight
+	BULKY_ITEM,// customer wants to not bag a bulky item
+	CANT_MAKE_CHANGE,// system could not make change
+	CANT_PRINT_RECEIPT,// system could not print the receipt 
+	ADD_ITEM_SEARCH,// customer wishes the attendant to search for an item for them
+	HELP_REQUESTED;// customer wants to signal the attendant for a reason not otherwise specified
 
 }


### PR DESCRIPTION
Changed how IssuePredictor works and expanded Attendant.
- IssuePredictor is now created by Attendant for a given instance of Session. The IssuePredictor for a given instance of Session can be retrieved from Attendant using a getter method. 
- Attendant now tracks the hardware (customer station) for each Session. Hardware can now be retrieved using a getter method in Attendant. 
- Attendant can now return the Request status for a given Session
- Attendant can now approve requests for a given Session
- added  an exception for when an Attendant is not tracking a given instance of Session

General code cleaning:
- added some file headers were they were missing
- aligned code with the changes I made
- added more documentation to Attendant  

Im gonna go to bed, goodnight. 